### PR TITLE
chore: updated ALLOWED_HOSTS

### DIFF
--- a/football_transfermarkt/football_transfermarkt/settings.py
+++ b/football_transfermarkt/football_transfermarkt/settings.py
@@ -19,7 +19,7 @@ SECRET_KEY = "django-insecure-sjjt_5jlaqkl+3^%b@zc4cc1n5^1x$4+3yx-qwg31$6d7-w=u^
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition


### PR DESCRIPTION
This pull request includes a small change to the `football_transfermarkt/settings.py` file. The change updates the `ALLOWED_HOSTS` setting to allow all hosts by default.

* [`football_transfermarkt/settings.py`](diffhunk://#diff-6dea268adc29b57af6dbf9f4546ae964c85177795d516b7371cf3f78644f3583L22-R22): Changed `ALLOWED_HOSTS` from an empty list to allow all hosts by default.